### PR TITLE
コミット対象のファイルが分かるようにしたい

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -129,6 +129,73 @@ func TestGetGitRootDir(t *testing.T) {
 	}
 }
 
+func TestGetStagedFiles(t *testing.T) {
+	// Create a temporary Git repository
+	tempDir := setupGitRepo(t)
+	defer os.RemoveAll(tempDir)
+
+	// Change to the repository directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+	defer os.Chdir(originalDir)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to repository directory: %v", err)
+	}
+
+	// Test with no staged files
+	files, err := GetStagedFiles()
+	if err != nil {
+		t.Fatalf("GetStagedFiles() failed: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("GetStagedFiles() = %v, want []", files)
+	}
+
+	// Create and stage multiple files
+	testFiles := []string{"file1.txt", "file2.go", "dir/file3.md"}
+	for _, file := range testFiles {
+		filePath := filepath.Join(tempDir, file)
+		dir := filepath.Dir(filePath)
+		if dir != tempDir {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create directory: %v", err)
+			}
+		}
+		if err := os.WriteFile(filePath, []byte("test content"), 0644); err != nil {
+			t.Fatalf("Failed to create test file %s: %v", file, err)
+		}
+	}
+
+	// Stage all files
+	cmd := exec.Command("git", "add", ".")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to stage files: %v", err)
+	}
+
+	// Test with staged files
+	files, err = GetStagedFiles()
+	if err != nil {
+		t.Fatalf("GetStagedFiles() failed: %v", err)
+	}
+	if len(files) != len(testFiles) {
+		t.Errorf("GetStagedFiles() returned %d files, want %d", len(files), len(testFiles))
+	}
+
+	// Verify all expected files are in the result
+	fileMap := make(map[string]bool)
+	for _, f := range files {
+		fileMap[f] = true
+	}
+	for _, expected := range testFiles {
+		if !fileMap[expected] {
+			t.Errorf("Expected file %s not found in staged files", expected)
+		}
+	}
+}
+
 func TestCommit(t *testing.T) {
 	// Skip in CI environments
 	if os.Getenv("CI") != "" {

--- a/internal/ui/components/commit_type.go
+++ b/internal/ui/components/commit_type.go
@@ -39,11 +39,12 @@ func (i commitTypeItem) Description() string { return i.description }
 
 // CommitTypeModel handles the commit type selection
 type CommitTypeModel struct {
-	list list.Model
+	list        list.Model
+	stagedFiles []string
 }
 
 // NewCommitTypeModel creates a new commit type model
-func NewCommitTypeModel(types []config.CommitType, useEmoji bool) CommitTypeModel {
+func NewCommitTypeModel(types []config.CommitType, useEmoji bool, stagedFiles []string) CommitTypeModel {
 	items := make([]list.Item, len(types))
 	for i, t := range types {
 		items[i] = commitTypeItem{
@@ -111,7 +112,8 @@ func NewCommitTypeModel(types []config.CommitType, useEmoji bool) CommitTypeMode
 		MarginBottom(1)
 
 	return CommitTypeModel{
-		list: listModel,
+		list:        listModel,
+		stagedFiles: stagedFiles,
 	}
 }
 
@@ -174,7 +176,16 @@ func (m CommitTypeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the model
 func (m CommitTypeModel) View() string {
+	// Build staged files display
+	filesDisplay := ""
+	if len(m.stagedFiles) > 0 {
+		filesDisplay = "\n\n📁 Staged files:\n"
+		for _, file := range m.stagedFiles {
+			filesDisplay += fmt.Sprintf("   • %s\n", file)
+		}
+	}
+
 	// Add a hint about number selection
 	hint := "\nTip: You can also select a commit type by pressing its number (1-" + fmt.Sprintf("%d", len(m.list.Items())) + ")"
-	return m.list.View() + hint
+	return m.list.View() + filesDisplay + hint
 }

--- a/internal/ui/components/commit_type_test.go
+++ b/internal/ui/components/commit_type_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/a1yama/git-cz-go/internal/config"
@@ -14,8 +15,8 @@ func TestNewCommitTypeModel(t *testing.T) {
 		{Type: "fix", Description: "A bug fix", Emoji: "🐛"},
 	}
 
-	// Create model with emoji disabled
-	model := NewCommitTypeModel(types, false)
+	// Create model with emoji disabled and no staged files
+	model := NewCommitTypeModel(types, false, []string{})
 
 	// Verify the model
 	view := model.View()
@@ -61,8 +62,9 @@ func TestCommitTypeModelUpdate(t *testing.T) {
 		{Type: "fix", Description: "A bug fix", Emoji: "🐛"},
 	}
 
-	// Create model
-	model := NewCommitTypeModel(types, false)
+	// Create model with staged files
+	stagedFiles := []string{"file1.txt", "src/main.go"}
+	model := NewCommitTypeModel(types, false, stagedFiles)
 
 	// Test window size message
 	windowSizeMsg := tea.WindowSizeMsg{Width: 100, Height: 50}
@@ -96,5 +98,35 @@ func TestCommitTypeModelUpdate(t *testing.T) {
 	// Check that a command was returned (for selecting the item)
 	if cmd == nil {
 		t.Error("Update() with numerical key press returned a nil command")
+	}
+}
+
+func TestCommitTypeModelViewWithStagedFiles(t *testing.T) {
+	// Create test commit types
+	types := []config.CommitType{
+		{Type: "feat", Description: "A new feature", Emoji: "✨"},
+		{Type: "fix", Description: "A bug fix", Emoji: "🐛"},
+	}
+
+	// Test with no staged files
+	model := NewCommitTypeModel(types, false, []string{})
+	view := model.View()
+	if strings.Contains(view, "Staged files:") {
+		t.Error("View() should not display staged files section when there are no staged files")
+	}
+
+	// Test with staged files
+	stagedFiles := []string{"file1.txt", "src/main.go", "README.md"}
+	model = NewCommitTypeModel(types, false, stagedFiles)
+	view = model.View()
+
+	if !strings.Contains(view, "Staged files:") {
+		t.Error("View() should display staged files section when there are staged files")
+	}
+
+	for _, file := range stagedFiles {
+		if !strings.Contains(view, file) {
+			t.Errorf("View() should display staged file %s", file)
+		}
 	}
 }

--- a/internal/ui/components/subject.go
+++ b/internal/ui/components/subject.go
@@ -14,13 +14,14 @@ type SubjectSubmittedMsg struct {
 
 // SubjectModel handles the commit subject input
 type SubjectModel struct {
-	textInput  textinput.Model
-	maxLength  int
-	validInput bool
+	textInput   textinput.Model
+	maxLength   int
+	validInput  bool
+	stagedFiles []string
 }
 
 // NewSubjectModel creates a new subject model
-func NewSubjectModel(maxLength int) SubjectModel {
+func NewSubjectModel(maxLength int, stagedFiles []string) SubjectModel {
 	ti := textinput.New()
 	ti.Placeholder = "Write a concise description of the change"
 	ti.Focus()
@@ -28,9 +29,10 @@ func NewSubjectModel(maxLength int) SubjectModel {
 	ti.Width = 50
 
 	return SubjectModel{
-		textInput:  ti,
-		maxLength:  maxLength,
-		validInput: false,
+		textInput:   ti,
+		maxLength:   maxLength,
+		validInput:  false,
+		stagedFiles: stagedFiles,
 	}
 }
 
@@ -89,6 +91,14 @@ func (m SubjectModel) View() string {
 		"\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("7")).Render("- Use imperative, present tense: \"add\" not \"added\"") +
 		"\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("7")).Render("- Don't capitalize the first letter") +
 		"\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("7")).Render("- No period at the end")
+
+	// Add staged files display
+	if len(m.stagedFiles) > 0 {
+		view += "\n\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Render("📁 Staged files:")
+		for _, file := range m.stagedFiles {
+			view += "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("7")).Render("   • "+file)
+		}
+	}
 
 	return view
 }

--- a/internal/ui/components/subject_test.go
+++ b/internal/ui/components/subject_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -8,7 +9,7 @@ import (
 
 func TestNewSubjectModel(t *testing.T) {
 	// Create model
-	model := NewSubjectModel(100)
+	model := NewSubjectModel(100, []string{})
 
 	// Verify the model
 	view := model.View()
@@ -24,8 +25,9 @@ func TestNewSubjectModel(t *testing.T) {
 }
 
 func TestSubjectModelUpdate(t *testing.T) {
-	// Create model
-	model := NewSubjectModel(100)
+	// Create model with staged files
+	stagedFiles := []string{"file1.txt", "src/main.go"}
+	model := NewSubjectModel(100, stagedFiles)
 
 	// Test window size message
 	windowSizeMsg := tea.WindowSizeMsg{Width: 100, Height: 50}
@@ -45,5 +47,29 @@ func TestSubjectModelUpdate(t *testing.T) {
 	// Check validation
 	if model.validInput {
 		t.Error("New model should have validInput=false")
+	}
+}
+
+func TestSubjectModelViewWithStagedFiles(t *testing.T) {
+	// Test with no staged files
+	model := NewSubjectModel(100, []string{})
+	view := model.View()
+	if strings.Contains(view, "Staged files:") {
+		t.Error("View() should not display staged files section when there are no staged files")
+	}
+
+	// Test with staged files
+	stagedFiles := []string{"file1.txt", "src/main.go", "README.md"}
+	model = NewSubjectModel(100, stagedFiles)
+	view = model.View()
+
+	if !strings.Contains(view, "Staged files:") {
+		t.Error("View() should display staged files section when there are staged files")
+	}
+
+	for _, file := range stagedFiles {
+		if !strings.Contains(view, file) {
+			t.Errorf("View() should display staged file %s", file)
+		}
 	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -23,6 +23,7 @@ type Model struct {
 	height        int
 	ready         bool
 	err           error
+	stagedFiles   []string
 }
 
 // Step represents a commit message input step
@@ -36,18 +37,25 @@ const (
 
 // New creates a new UI model
 func New(cfg *config.Config) Model {
+	// Get staged files
+	stagedFiles, err := git.GetStagedFiles()
+	if err != nil {
+		stagedFiles = []string{} // Continue with empty list on error
+	}
+
 	// ステップを初期化
 	steps := []tea.Model{
-		components.NewCommitTypeModel(cfg.Types, cfg.UseEmoji),
-		components.NewSubjectModel(cfg.MaxSubjectLength),
+		components.NewCommitTypeModel(cfg.Types, cfg.UseEmoji, stagedFiles),
+		components.NewSubjectModel(cfg.MaxSubjectLength, stagedFiles),
 		components.NewConfirmModel(),
 	}
 
 	return Model{
-		config:     cfg,
-		activeStep: 0,
-		steps:      steps, // 初期化したステップを設定
-		ready:      false,
+		config:      cfg,
+		activeStep:  0,
+		steps:       steps, // 初期化したステップを設定
+		ready:       false,
+		stagedFiles: stagedFiles,
 	}
 }
 
@@ -57,8 +65,8 @@ func (m Model) Init() tea.Cmd {
 	if len(m.steps) == 0 {
 		// 万が一ステップが空の場合は、ここで初期化
 		m.steps = []tea.Model{
-			components.NewCommitTypeModel(m.config.Types, m.config.UseEmoji),
-			components.NewSubjectModel(m.config.MaxSubjectLength),
+			components.NewCommitTypeModel(m.config.Types, m.config.UseEmoji, m.stagedFiles),
+			components.NewSubjectModel(m.config.MaxSubjectLength, m.stagedFiles),
 			components.NewConfirmModel(),
 		}
 	}


### PR DESCRIPTION
## Summary
- commit type選択時とコミットメッセージ入力時にステージングされたファイル一覧を表示する機能を追加
- git diffコマンドを使用してコミット対象のファイルを取得し、相対パスで表示
- 各コンポーネントにテストを追加し、動作を保証

## Test plan
- [x] GetStagedFiles関数のテストが成功すること
- [x] commit type画面でファイル一覧が表示されること
- [x] コミットメッセージ入力画面でファイル一覧が表示されること
- [x] ファイルがステージングされていない場合は一覧が表示されないこと
- [x] 全テストがパスすること（go test ./...）
- [x] コードフォーマットとLintのチェックが通ること

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)